### PR TITLE
Link detail badges to filtered catalog

### DIFF
--- a/client/e2e-tests/games.spec.ts
+++ b/client/e2e-tests/games.spec.ts
@@ -131,6 +131,72 @@ test.describe('Game Listing and Navigation', () => {
     await expect(page.getByTestId('games-grid')).toBeVisible();
   });
 
+  test('should filter games when clicking the category badge on details page', async ({ page }) => {
+    await page.goto('/game/1');
+
+    const categoryLink = page.getByTestId('game-details-category');
+    await expect(categoryLink).toBeVisible();
+
+    const categoryHref = await categoryLink.getAttribute('href');
+    expect(categoryHref).toBeTruthy();
+
+    const categoryUrl = new URL(categoryHref ?? '', 'http://localhost:4321');
+    const expectedCategoryId = categoryUrl.searchParams.get('category_id');
+    expect(expectedCategoryId).toBeTruthy();
+
+    const categoryName = (await categoryLink.innerText()).trim();
+
+    await Promise.all([
+      page.waitForURL((url) => url.toString().includes('category_id=')),
+      categoryLink.click()
+    ]);
+
+    await expect(page).toHaveURL(new RegExp(`category_id=${expectedCategoryId}`));
+    await expect(page.getByTestId('games-grid')).toBeVisible();
+
+    const gameCards = page.getByTestId('game-card');
+    expect(await gameCards.count()).toBeGreaterThan(0);
+
+    const categoryBadges = page.getByTestId('game-category');
+    const badgeCount = await categoryBadges.count();
+    for (let index = 0; index < badgeCount; index += 1) {
+      await expect(categoryBadges.nth(index)).toHaveText(categoryName);
+    }
+  });
+
+  test('should filter games when clicking the publisher badge on details page', async ({ page }) => {
+    await page.goto('/game/1');
+
+    const publisherLink = page.getByTestId('game-details-publisher');
+    await expect(publisherLink).toBeVisible();
+
+    const publisherHref = await publisherLink.getAttribute('href');
+    expect(publisherHref).toBeTruthy();
+
+    const publisherUrl = new URL(publisherHref ?? '', 'http://localhost:4321');
+    const expectedPublisherId = publisherUrl.searchParams.get('publisher_id');
+    expect(expectedPublisherId).toBeTruthy();
+
+    const publisherName = (await publisherLink.innerText()).trim();
+
+    await Promise.all([
+      page.waitForURL((url) => url.toString().includes('publisher_id=')),
+      publisherLink.click()
+    ]);
+
+    await expect(page).toHaveURL(new RegExp(`publisher_id=${expectedPublisherId}`));
+    await expect(page.getByTestId('games-grid')).toBeVisible();
+
+    const gameCards = page.getByTestId('game-card');
+    expect(await gameCards.count()).toBeGreaterThan(0);
+
+    const publisherBadges = page.getByTestId('game-publisher');
+    const badgeCount = await publisherBadges.count();
+    for (let index = 0; index < badgeCount; index += 1) {
+      await expect(publisherBadges.nth(index)).toHaveText(publisherName);
+    }
+  });
+
   test('should handle navigation to non-existent game gracefully', async ({ page }) => {
     // Navigate to a game that doesn't exist
     const response = await page.goto('/game/99999');

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1639,6 +1639,7 @@
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -2165,6 +2166,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2317,6 +2319,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.0.tgz",
       "integrity": "sha512-GaDRs2Mngpw3dr2vc085GnORh98NiXxwIjg/EoQQQl/icZt3Z7s0BRsYHDZ8swkZbOA6wZsqWJdrNirl+iKcDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -2566,6 +2569,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5464,6 +5468,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5841,6 +5846,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.1.tgz",
       "integrity": "sha512-33xGNBsDJAkzt0PvninskHlWnTIPgDtTwhg0U38CUoNP/7H6wI2Cz6dUeoNPbjdTdsYTGuiFFASuUOWovH0SyQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6112,6 +6118,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.43.14.tgz",
       "integrity": "sha512-pHeUrp1A5S6RGaXhJB7PtYjL1VVjbVrJ2EfuAoPu9/1LeoMaJa/pcdCsCSb0gS4eUHAHnhCbUDxORZyvGK6kOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -6311,6 +6318,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6699,6 +6707,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7310,6 +7319,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1639,7 +1639,6 @@
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -2166,7 +2165,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2319,7 +2317,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.0.tgz",
       "integrity": "sha512-GaDRs2Mngpw3dr2vc085GnORh98NiXxwIjg/EoQQQl/icZt3Z7s0BRsYHDZ8swkZbOA6wZsqWJdrNirl+iKcDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -2569,7 +2566,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5468,7 +5464,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5846,7 +5841,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.1.tgz",
       "integrity": "sha512-33xGNBsDJAkzt0PvninskHlWnTIPgDtTwhg0U38CUoNP/7H6wI2Cz6dUeoNPbjdTdsYTGuiFFASuUOWovH0SyQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6118,7 +6112,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.43.14.tgz",
       "integrity": "sha512-pHeUrp1A5S6RGaXhJB7PtYjL1VVjbVrJ2EfuAoPu9/1LeoMaJa/pcdCsCSb0gS4eUHAHnhCbUDxORZyvGK6kOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -6318,7 +6311,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6707,7 +6699,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7319,7 +7310,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/src/components/GameDetails.svelte
+++ b/client/src/components/GameDetails.svelte
@@ -100,14 +100,24 @@
             
             <div class="flex flex-wrap gap-2 mt-4 mb-6">
                 {#if gameData.category}
-                    <span class="text-xs font-medium px-2.5 py-0.5 rounded bg-blue-900/60 text-blue-300" data-testid="game-details-category">
+                    <a
+                        href={`/?category_id=${gameData.category.id}`}
+                        class="text-xs font-medium px-2.5 py-0.5 rounded bg-blue-900/60 text-blue-300 hover:bg-blue-800/80 hover:text-blue-200 transition-colors"
+                        data-testid="game-details-category"
+                        data-category-id={gameData.category.id}
+                    >
                         {gameData.category.name}
-                    </span>
+                    </a>
                 {/if}
                 {#if gameData.publisher}
-                    <span class="text-xs font-medium px-2.5 py-0.5 rounded bg-purple-900/60 text-purple-300" data-testid="game-details-publisher">
+                    <a
+                        href={`/?publisher_id=${gameData.publisher.id}`}
+                        class="text-xs font-medium px-2.5 py-0.5 rounded bg-purple-900/60 text-purple-300 hover:bg-purple-800/80 hover:text-purple-200 transition-colors"
+                        data-testid="game-details-publisher"
+                        data-publisher-id={gameData.publisher.id}
+                    >
                         {gameData.publisher.name}
-                    </span>
+                    </a>
                 {/if}
             </div>
             

--- a/client/src/components/GameList.svelte
+++ b/client/src/components/GameList.svelte
@@ -70,7 +70,32 @@
     $: totalItems = pagination.total_items;
     $: showingStart = totalItems === 0 ? 0 : (pagination.page - 1) * pagination.per_page + 1;
     $: showingEnd = totalItems === 0 ? 0 : Math.min(pagination.page * pagination.per_page, totalItems);
-    $: pageNumbers = Array.from({ length: pagination.total_pages }, (_, index) => index + 1);
+    /**
+     * Smart pagination: returns an array of page numbers and ellipsis for display.
+     * Always shows first, last, current, and up to 2 pages before/after current.
+     */
+    $: paginationItems = (() => {
+        const total = pagination.total_pages;
+        const current = pagination.page;
+        const windowSize = 2; // pages before/after current
+        if (total <= 7) {
+            // Show all if few pages
+            return Array.from({ length: total }, (_, i) => i + 1);
+        }
+        const items: (number | string)[] = [];
+        items.push(1);
+        if (current > windowSize + 2) {
+            items.push('...');
+        }
+        for (let i = Math.max(2, current - windowSize); i <= Math.min(total - 1, current + windowSize); i++) {
+            items.push(i);
+        }
+        if (current < total - windowSize - 1) {
+            items.push('...');
+        }
+        items.push(total);
+        return items;
+    })();
 
     const syncFiltersFromUrl = (): void => {
         if (typeof window === 'undefined') {

--- a/client/src/components/GameList.svelte
+++ b/client/src/components/GameList.svelte
@@ -263,7 +263,7 @@
                 >
                     <option value="">All Categories</option>
                     {#each categories as category}
-                        <option value={category.id}>{category.name}</option>
+                        <option value={category.id.toString()}>{category.name}</option>
                     {/each}
                 </select>
 
@@ -275,7 +275,7 @@
                 >
                     <option value="">All Publishers</option>
                     {#each publishers as publisher}
-                        <option value={publisher.id}>{publisher.name}</option>
+                        <option value={publisher.id.toString()}>{publisher.name}</option>
                     {/each}
                 </select>
             </div>
@@ -396,15 +396,19 @@
                     </button>
 
                     <div class="flex items-center gap-1">
-                        {#each pageNumbers as pageNumber}
-                            <button
-                                class={`w-9 h-9 rounded-lg border text-sm ${pageNumber === pagination.page ? 'border-blue-500 bg-blue-500/20 text-blue-300 font-semibold' : 'border-slate-700 bg-slate-800 text-slate-200 hover:bg-slate-700'}`}
-                                on:click={() => changePage(pageNumber)}
-                                aria-current={pageNumber === pagination.page ? 'page' : undefined}
-                                aria-label={`Page ${pageNumber}`}
-                            >
-                                {pageNumber}
-                            </button>
+                        {#each paginationItems as item}
+                            {#if item === '...'}
+                                <span class="w-9 h-9 flex items-center justify-center text-slate-400">…</span>
+                            {:else}
+                                <button
+                                    class={`w-9 h-9 rounded-lg border text-sm ${item === pagination.page ? 'border-blue-500 bg-blue-500/20 text-blue-300 font-semibold' : 'border-slate-700 bg-slate-800 text-slate-200 hover:bg-slate-700'}`}
+                                    on:click={() => changePage(item)}
+                                    aria-current={item === pagination.page ? 'page' : undefined}
+                                    aria-label={`Page ${item}`}
+                                >
+                                    {item}
+                                </button>
+                            {/if}
                         {/each}
                     </div>
 

--- a/client/src/components/GameList.svelte
+++ b/client/src/components/GameList.svelte
@@ -122,6 +122,11 @@
         }
     };
 
+    /**
+     * Updates the browser URL with current filter and pagination state.
+     * This function synchronizes the URL query parameters with the active filters,
+     * page number, and page size, allowing users to bookmark or share filtered views.
+     */
     const updateBrowserUrl = (paginationState: Pagination): void => {
         if (typeof window === 'undefined') {
             return;

--- a/client/src/components/GameList.svelte
+++ b/client/src/components/GameList.svelte
@@ -402,7 +402,7 @@
                             {:else}
                                 <button
                                     class={`w-9 h-9 rounded-lg border text-sm ${item === pagination.page ? 'border-blue-500 bg-blue-500/20 text-blue-300 font-semibold' : 'border-slate-700 bg-slate-800 text-slate-200 hover:bg-slate-700'}`}
-                                    on:click={() => changePage(item)}
+                                    on:click={() => typeof item === 'number' && changePage(item)}
                                     aria-current={item === pagination.page ? 'page' : undefined}
                                     aria-label={`Page ${item}`}
                                 >


### PR DESCRIPTION
## Summary
- make category and publisher badges on game detail pages link back to filtered catalog views
- sync the games listing filters and pagination state with URL parameters for shareable links
- add e2e coverage confirming badge navigation filters the grid as expected

## Related Issue
Closes #10

## Testing
- `bash scripts/run-server-tests.sh`
- `npm run build`
- `CI=1 npx playwright test`
